### PR TITLE
Assign cart-empty class when cart is empty

### DIFF
--- a/addon/components/cart-counter.js
+++ b/addon/components/cart-counter.js
@@ -1,8 +1,15 @@
 import Ember from 'ember';
 import layout from '../templates/components/cart-counter';
 
+const {
+  computed
+} = Ember;
+
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'span',
-  classNames: ['cart-counter']
+  classNames: ['cart-counter'],
+  classNameBindings: ['isEmpty::cart-empty'],
+
+  isEmpty: computed.bool('cart.counter')
 });

--- a/addon/components/cart-items.js
+++ b/addon/components/cart-items.js
@@ -1,8 +1,15 @@
 import Ember from 'ember';
 import layout from '../templates/components/cart-items';
 
+const {
+  computed
+} = Ember;
+
 export default Ember.Component.extend({
   layout: layout,
   tagName: 'ul',
-  classNames: ['cart-items']
+  classNames: ['cart-items'],
+  classNameBindings: ['isEmpty::cart-empty'],
+
+  isEmpty: computed.bool('cart.counter')
 });

--- a/tests/unit/components/cart-counter-test.js
+++ b/tests/unit/components/cart-counter-test.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
+
+const set = Ember.set;
 
 moduleForComponent('cart-counter', 'Unit | Component | cart counter', {
   // Specify the other units that are required for this test
@@ -10,10 +13,36 @@ test('it renders', function(assert) {
   assert.expect(2);
 
   // Creates the component instance
-  var component = this.subject();
+  let component = this.subject();
   assert.equal(component._state, 'preRender');
 
   // Renders the component to the page
   this.render();
   assert.equal(component._state, 'inDOM');
+});
+
+test('adds the class "empty" when the cart is empty', function(assert) {
+  let component = this.subject();
+
+  let cart = {
+    counter: 0
+  };
+
+  set(component, 'cart', cart);
+  this.render();
+
+  assert.ok(this.$().hasClass('cart-empty'));
+});
+
+test('removes the class "empty" when the cart is not empty', function(assert) {
+  let component = this.subject();
+
+  let cart = {
+    counter: 1
+  };
+
+  set(component, 'cart', cart);
+  this.render();
+
+  assert.ok(!this.$().hasClass('cart-empty'));
 });

--- a/tests/unit/components/cart-items-test.js
+++ b/tests/unit/components/cart-items-test.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
+
+const set = Ember.set;
 
 moduleForComponent('cart-items', 'Unit | Component | cart items', {
   // Specify the other units that are required for this test
@@ -16,4 +19,32 @@ test('it renders', function(assert) {
   // Renders the component to the page
   this.render();
   assert.equal(component._state, 'inDOM');
+});
+
+test('adds the class "empty" when the cart is empty', function(assert) {
+  let component = this.subject();
+
+  let cart = Ember.ArrayProxy.create({
+    content: Ember.A(),
+    counter: 0
+  });
+
+  set(component, 'cart', cart);
+  this.render();
+
+  assert.ok(this.$().hasClass('cart-empty'));
+});
+
+test('removes the class "empty" when the cart is not empty', function(assert) {
+  let component = this.subject();
+
+  let cart = Ember.ArrayProxy.create({
+    content: Ember.A(),
+    counter: 1
+  });
+
+  set(component, 'cart', cart);
+  this.render();
+
+  assert.ok(!this.$().hasClass('cart-empty'));
 });


### PR DESCRIPTION
Applies to {{cart-items}} and {{cart-counter}}
