### PR TITLE
Fix dumpToLocalStorate guard race condition

### DIFF
--- a/addon/instance-initializers/cart.js
+++ b/addon/instance-initializers/cart.js
@@ -2,14 +2,18 @@ import Ember from 'ember';
 
 export function initialize(appInstance) {
   const CartService = appInstance.container.lookupFactory('service:cart');
+  let payload;
+
+  if (window.localStorage.getItem('cart')) {
+    payload = window.localStorage.getItem('cart');
+    payload = JSON.parse(payload);
+  }
 
   let cart = CartService.create({
     content: Ember.A()
   });
 
-  if (cart.localStorage && window.localStorage.getItem('cart')) {
-    let payload = window.localStorage.getItem('cart');
-    payload = JSON.parse(payload);
+  if (payload && cart.localStorage) {
     cart.pushPayload(payload);
   }
 

--- a/addon/services/cart.js
+++ b/addon/services/cart.js
@@ -54,7 +54,6 @@ export default ArrayProxy.extend({
 
   clearItems() {
     this.clear();
-    window.localStorage.removeItem('cart');
   },
 
   total: computed('@each.total', function() {
@@ -69,7 +68,7 @@ export default ArrayProxy.extend({
   counter: computed.alias('length'),
 
   _dumpToLocalStorage: observer('[]', '@each.quantity', on('init', function() {
-    if (get(this, 'isNotEmpty') && this.localStorage) {
+    if (this.localStorage) {
       window.localStorage.setItem('cart', JSON.stringify(this.payload()));
     }
   }))

--- a/tests/unit/services/cart-test.js
+++ b/tests/unit/services/cart-test.js
@@ -7,7 +7,7 @@ const set = Ember.set;
 
 moduleFor('service:cart', 'Unit | Service | cart', {
   needs: ['model:cart-item'],
-  afterEeach() {
+  beforeEeach() {
     window.localStorage.removeItem('cart');
   }
 });
@@ -157,7 +157,7 @@ test('dumps to localStorage on every write action when flag is set', function(as
     localStorage: true
   });
 
-  assert.equal(window.localStorage.getItem('cart'), null, 'cart should start cleared');
+  assert.equal(window.localStorage.getItem('cart'), '[]', 'cart should start cleared');
 
   cart.pushItem({
     name: 'Foo',
@@ -191,7 +191,7 @@ test('dumps to localStorage on every write action when flag is set', function(as
 
   cart.clearItems();
 
-  assert.equal(window.localStorage.getItem('cart'), null, 'cart should be cleared out');
+  assert.equal(window.localStorage.getItem('cart'), '[]', 'cart should be cleared out');
 });
 
 test('pushPayload', function(assert) {


### PR DESCRIPTION
- Remove `isNotEmpty` guard for `_dumpToLocalStorage` becuase we want
  localStorage to be updated if we remove items from the cart via
  `removeItem`.
