### PR TITLE
Avoid quantity incrementing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ actions: {
 Make sure to use `clearItems()` and not `clear()` as the former will
 ensure that `localStorage` is properly cleared out.
 
+### Avoiding quantity incrementation
+
+You may only allow one of a specific type. To enforce the quantity
+doesn't increment you should set `increment: false` for the Cart Item:
+
+```js
+this.cart.pushItem({
+  name: 'Foo',
+  price: 100,
+  increment: false
+});
+```
+
 ## Authors ##
 
 * [Brian Cardarella](http://twitter.com/bcardarella)

--- a/addon/models/cart-item.js
+++ b/addon/models/cart-item.js
@@ -8,6 +8,7 @@ const {
 const get = Ember.get;
 
 export default Ember.Object.extend({
+  increment: true,
   quantity: 0,
   price: 0,
 

--- a/addon/services/cart.js
+++ b/addon/services/cart.js
@@ -27,7 +27,10 @@ export default ArrayProxy.extend({
     }
 
     cartItem = foundCartItem || cartItem;
-    cartItem.incrementProperty('quantity');
+
+    if (get(cartItem, 'increment') || get(cartItem, 'quantity') === 0) {
+      cartItem.incrementProperty('quantity');
+    }
   },
 
   localStorage: false,

--- a/tests/unit/services/cart-test.js
+++ b/tests/unit/services/cart-test.js
@@ -138,6 +138,30 @@ test('payload dump', function(assert) {
   ]);
 });
 
+test('pushing an item that cannot be incremented', function(assert) {
+  let cart = this.subject({
+    content: Ember.A()
+  });
+
+  cart.pushItem({
+    name: 'Foo',
+    price: 100,
+    increment: false
+  });
+
+  cart.pushItem({
+    name: 'Foo',
+    price: 100,
+    increment: false
+  });
+
+  let payload = cart.payload();
+
+  assert.deepEqual(payload, [
+    { name: 'Foo', price: 100, quantity: 1 }
+  ]);
+});
+
 test('does not save to localStorage by default', function(assert) {
   let cart = this.subject({
     content: Ember.A()


### PR DESCRIPTION
Adding `increment: false` to the model will prevent quantity
incrementing
